### PR TITLE
Change build so that this will run in Docker on arm64/aarch64

### DIFF
--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,34 +1,29 @@
-FROM ubuntu:22.04
+FROM continuumio/miniconda3:main
 
-RUN apt update && apt install -y git wget
+ENV SWE_BENCH_REPO=https://github.com/yuntongzhang/SWE-bench.git
 
-WORKDIR /root
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-RUN bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /root/miniconda3
-ENV PATH="/root/miniconda3/bin:${PATH}"
+ENV GIT_NAME=acr
+ENV GIT_EMAIL=acr@nus.edu.sg
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y \
+    git wget vim \
+    libffi-dev python3-pytest pkg-config build-essential libssl-dev \
+    libfreetype6-dev libqhull-dev \
+    texlive cm-super dvipng python-tk ffmpeg \
+    imagemagick fontconfig ghostscript inkscape graphviz \
+    optipng fonts-comic-neue  python3-pikepdf
+
+RUN git config --global user.name ${GIT_NAME} && \
+    git config --global user.email ${GIT_EMAIL}
+
 RUN conda init
 
-WORKDIR /opt
-RUN git clone https://github.com/yuntongzhang/SWE-bench.git
-
+RUN git clone ${SWE_BENCH_REPO} /opt/SWE-bench
 WORKDIR /opt/SWE-bench
 RUN conda env create -f environment.yml
 RUN ln -sf /bin/bash /bin/sh
-
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt install -y libffi-dev python3-pytest libfreetype6-dev libqhull-dev
-RUN apt install -y pkg-config texlive cm-super dvipng python-tk ffmpeg
-RUN apt install -y imagemagick fontconfig
-RUN apt install -y ghostscript inkscape graphviz
-RUN apt install -y optipng fonts-comic-neue  python3-pikepdf
-
-RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
-RUN apt install -y ttf-mscorefonts-installer
-
-RUN apt install -y vim build-essential libssl-dev
-
-RUN git config --global user.email acr@nus.edu.sg
-RUN git config --global user.name acr
 
 COPY . /opt/auto-code-rover
 WORKDIR /opt/auto-code-rover

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,9 +1,9 @@
 FROM continuumio/miniconda3:main
 
-ENV SWE_BENCH_REPO=https://github.com/yuntongzhang/SWE-bench.git
+ARG SWE_BENCH_REPO=https://github.com/yuntongzhang/SWE-bench.git
 
-ENV GIT_NAME=acr
-ENV GIT_EMAIL=acr@nus.edu.sg
+ARG GIT_NAME=acr
+ARG GIT_EMAIL=acr@nus.edu.sg
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ The output of the run can then be found in `output/`. For example, the patch gen
 First, put the id's of all tasks to run in a file, one per line. Suppose this file is `tasks.txt`, the tasks can be run with
 
 ```
-PYTHONPATH=. python app/main.py --enable-layered --model gpt-4-0125-preview --setup-map ../SWE-bench/setup_result/setup_map.json --tasks-map ../SWE-bench/setup_result/tasks_map.json --output-dir output --task-list-file tasks.txt
+cd /opt/auto-code-rover
+conda activate auto-code-rover
+PYTHONPATH=. python app/main.py --enable-layered --model gpt-4-0125-preview --setup-map ../SWE-bench/setup_result/setup_map.json --tasks-map ../SWE-bench/setup_result/tasks_map.json --output-dir output --task-list-file /opt/SWE-bench/tasks.txt
 ```
 
 **NOTE**: make sure that the tasks in `tasks.txt` have all been set up in SWE-bench. See the steps [above](#set-up-one-or-more-tasks-in-swe-bench).

--- a/README.md
+++ b/README.md
@@ -74,8 +74,22 @@ export OPENAI_KEY=sk-YOUR-OPENAI-API-KEY-HERE
 Build and start the docker image:
 
 ```
+docker build -f Dockerfile -t acr .
+docker run -it -e OPENAI_KEY="${OPENAI_KEY:-OPENAI_API_KEY}" acr 
+```
+
+Dockerfile.scratch will build both SWE-bench (from https://github.com/yuntongzhang/SWE-bench.git) and ACR.  That supports arm64 (Apple silicon) and ppc in addition to amd64.
+
+```
 docker build -f Dockerfile.scratch -t acr .
-docker run -it -e OPENAI_KEY="${OPENAI_API_KEY:-$OPENAI_KEY}" acr 
+```
+
+There are build args for customizing the build like this:
+
+```
+docker build --build-arg GIT_EMAIL=your@email.com --build-arg GIT_NAME=your_id \
+       --build-arg SWE_BENCH_REPO=https://github.com/your_id/SWE-bench.git \
+       -f Dockerfile.scratch -t acr .
 ```
 
 ### Set up one or more tasks in SWE-bench

--- a/README.md
+++ b/README.md
@@ -64,17 +64,18 @@ https://github.com/nus-apr/auto-code-rover/assets/48704330/26c9d5d4-04e0-4b98-be
 ## 🚀 Setup & Running
 
 We recommend running AutoCodeRover in a Docker container.
-First of all, build and start the docker image:
+
+Set the `OPENAI_KEY` env var to your [OpenAI key](https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key):
 
 ```
-docker build -f Dockerfile -t acr .
-docker run -it acr
+export OPENAI_KEY=sk-YOUR-OPENAI-API-KEY-HERE
 ```
 
-In the docker container, set the `OPENAI_KEY` env var to your [OpenAI key](https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key):
+Build and start the docker image:
 
 ```
-export OPENAI_KEY=xx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+docker build -f Dockerfile.scratch -t acr .
+docker run -it -e OPENAI_KEY="${OPENAI_API_KEY:-$OPENAI_KEY}" acr 
 ```
 
 ### Set up one or more tasks in SWE-bench
@@ -86,6 +87,12 @@ The tasks need to be put in a file, one per line:
 ```
 cd /opt/SWE-bench
 echo django__django-11133 > tasks.txt
+```
+
+Or if running on arm64 (e.g. Apple silicon), try this one which doesn't depend on Python 3.6 (which isn't supported in this env):
+
+```
+echo django__django-16041 > tasks.txt
 ```
 
 Then, set up these tasks by running:

--- a/environment.yml
+++ b/environment.yml
@@ -3,28 +3,28 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - _libgcc_mutex=0.1=conda_forge
-  - _openmp_mutex=4.5=2_gnu
-  - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2023.12.12=h06a4308_0
-  - ld_impl_linux-64=2.38=h1181459_1
-  - libffi=3.4.4=h6a678d5_0
-  - libgcc-ng=13.2.0=h807b86a_3
-  - libgomp=13.2.0=h807b86a_3
-  - libstdcxx-ng=11.2.0=h1234567_1
-  - libuuid=1.41.5=h5eee18b_0
-  - ncurses=6.4=h6a678d5_0
-  - openssl=3.2.0=hd590300_1
-  - pip=23.3.1=py311h06a4308_0
-  - python=3.11.7=h955ad1f_0
-  - readline=8.2=h5eee18b_0
-  - setuptools=68.2.2=py311h06a4308_0
-  - sqlite=3.41.2=h5eee18b_0
-  - tk=8.6.12=h1ccaba5_0
-  - tzdata=2023d=h04d1e81_0
-  - wheel=0.41.2=py311h06a4308_0
-  - xz=5.4.5=h5eee18b_0
-  - zlib=1.2.13=h5eee18b_0
+  - _libgcc_mutex=0.1
+  - _openmp_mutex=4.5
+  - bzip2=1.0.8
+  - ca-certificates=2023.12.12
+  - ld_impl_linux-64
+  - libffi=3.4.4
+  - libgcc-ng=13.2.0
+  - libgomp=13.2.0
+  - libstdcxx-ng=11.2.0
+  - libuuid=1.41.5
+  - ncurses=6.4
+  - openssl=3.2.0
+  - pip=23.3.1
+  - python=3.11.7
+  - readline=8.2
+  - setuptools=68.2.2
+  - sqlite=3.41.2
+  - tk=8.6.12
+  - tzdata=2023d
+  - wheel=0.41.2
+  - xz=5.4.5
+  - zlib=1.2.13
   - unidiff
   - pip:
       - annotated-types==0.6.0


### PR DESCRIPTION
Changes so folks using on arm64, like Apple silicon Macs, can run natively in Docker.

Use the official Miniconda DockerHub image (continuumio/miniconda3). The source for that Dockerfile is here: https://github.com/ContinuumIO/docker-images/tree/main/miniconda3).

Remove the hashes from the environment.yaml because they aren't the same between amd64 and arm64.

Tweakage to the README.

One problem with running on arm64 is that Miniconda's repo doesn't have Python 3.6. There are two things to do about that. One is to change the task runner to skip tasks that fail configuration (instead of crashing) and the other is to see if there is a reasonable way to get Python 3.6 working in this setup.