### PR TITLE
Fix docker build issue on M1 Mac

### DIFF
--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -11,7 +11,7 @@ RUN apt update && apt install -y \
     git wget vim \
     libffi-dev python3-pytest pkg-config build-essential libssl-dev \
     libfreetype6-dev libqhull-dev \
-    texlive cm-super dvipng python-tk ffmpeg \
+    texlive cm-super dvipng ffmpeg \
     imagemagick fontconfig ghostscript inkscape graphviz \
     optipng fonts-comic-neue  python3-pikepdf
 

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,6 @@ dependencies:
   - wheel=0.41.2
   - xz=5.4.5
   - zlib=1.2.13
-  - unidiff=0.7.5
   - loguru=0.7.2
   - requests=2.31.0
   - rich=13.7.1
@@ -61,3 +60,4 @@ dependencies:
       - ollama==0.1.8
       - flask==3.0.3
       - flask_cors==4.0.0
+      - unidiff==0.7.5


### PR DESCRIPTION
Fixes #43.

- Removes `python-tk` in Dockerfile, as it is a potential dependency for SWE-bench subjects, but not for ACR.
- Use `pip` instead of `conda` to resolve `unidiff`.