### PR TITLE
demo_vis port optimize , only  3000 port need expose out. 

### DIFF
--- a/demo_vis/front/app/page.tsx
+++ b/demo_vis/front/app/page.tsx
@@ -206,7 +206,7 @@ export default function App() {
   };
 
   const onsubmmit_callback = async (data: FieldValues) => {
-    const call_server = fetch('http://localhost:5000/api/run_github_issue', {
+    const call_server = fetch('http://localhost:3000/api/run_github_issue', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/demo_vis/front/next.config.mjs
+++ b/demo_vis/front/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+
+    async rewrites() {
+        return [
+                {
+                        source: '/api/:path*',
+                        destination: `http://localhost:5000/api/:path*`,
+                },
+        ]
+    },
+
+};
 
 export default nextConfig;


### PR DESCRIPTION
When run demo_vis in docker , need expose 3000,5000 port ,  so I add API proxy in next.config.mjs  ,  now you only need expose 3000 port  for your browser.


#source code 
const nextConfig = {

    async rewrites() {
        return [
                {
                        source: '/api/:path*',
                        destination: `http://localhost:5000/api/:path*`,
                },
        ]
    },

};